### PR TITLE
Accept arbitrary RSA crypto.Signer implementations

### DIFF
--- a/cmd/acme/cert.go
+++ b/cmd/acme/cert.go
@@ -13,6 +13,7 @@ package main
 
 import (
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -166,7 +167,7 @@ func authz(client *acme.Client, zurl, domain string) error {
 
 	if certManual {
 		// manual challenge response
-		tok := fmt.Sprintf("%s.%s", chal.Token, acme.JWKThumbprint(&client.Key.PublicKey))
+		tok := fmt.Sprintf("%s.%s", chal.Token, acme.JWKThumbprint(client.Key.Public().(*rsa.PublicKey)))
 		file, err := challengeFile(domain, tok)
 		if err != nil {
 			return err

--- a/errors.go
+++ b/errors.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"time"
 )
 
@@ -71,4 +72,12 @@ type RetryError time.Duration
 
 func (re RetryError) Error() string {
 	return fmt.Sprintf("retry after %s", re)
+}
+
+type UnsupportedKeyError struct {
+	Type reflect.Type
+}
+
+func (e *UnsupportedKeyError) Error() string {
+	return fmt.Sprintf("acme: unsupported key type: %s", e.Type)
 }

--- a/jws.go
+++ b/jws.go
@@ -26,7 +26,11 @@ import (
 // The result is serialized in JSON format.
 // See https://tools.ietf.org/html/rfc7515#section-7.
 func jwsEncodeJSON(claimset interface{}, key crypto.Signer, nonce string) ([]byte, error) {
-	jwk := jwkEncode(key.Public().(*rsa.PublicKey))
+	pub, err := keyPub(key)
+	if err != nil {
+		return nil, err
+	}
+	jwk := jwkEncode(pub)
 	phead := fmt.Sprintf(`{"alg":"RS256","jwk":%s,"nonce":%q}`, jwk, nonce)
 	phead = base64.RawURLEncoding.EncodeToString([]byte(phead))
 	cs, err := json.Marshal(claimset)

--- a/jws.go
+++ b/jws.go
@@ -25,8 +25,8 @@ import (
 // jwsEncodeJSON signs claimset using provided key and a nonce.
 // The result is serialized in JSON format.
 // See https://tools.ietf.org/html/rfc7515#section-7.
-func jwsEncodeJSON(claimset interface{}, key *rsa.PrivateKey, nonce string) ([]byte, error) {
-	jwk := jwkEncode(&key.PublicKey)
+func jwsEncodeJSON(claimset interface{}, key crypto.Signer, nonce string) ([]byte, error) {
+	jwk := jwkEncode(key.Public().(*rsa.PublicKey))
 	phead := fmt.Sprintf(`{"alg":"RS256","jwk":%s,"nonce":%q}`, jwk, nonce)
 	phead = base64.RawURLEncoding.EncodeToString([]byte(phead))
 	cs, err := json.Marshal(claimset)
@@ -36,7 +36,7 @@ func jwsEncodeJSON(claimset interface{}, key *rsa.PrivateKey, nonce string) ([]b
 	payload := base64.RawURLEncoding.EncodeToString(cs)
 	h := sha256.New()
 	h.Write([]byte(phead + "." + payload))
-	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, h.Sum(nil))
+	sig, err := key.Sign(rand.Reader, h.Sum(nil), crypto.SHA256)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows using HSMs and other types of keys where the private key is
not accessible.