### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Quick install with `go get -u github.com/google/acme/cmd/acme`.
 1. You need to have a user account, registered with the CA. This is represented
   by an RSA private key.
 
-  If you already have a key, you can just run:
+  The easiest is to let the `acme` tool generate it for you:
 
-        acme reg mailto:email@example.com
+        acme reg -gen mailto:email@example.com
 
   If you want to generate a key manually:
 

--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ Quick install with `go get -u github.com/google/acme/cmd/acme`.
 1. You need to have a user account, registered with the CA. This is represented
   by an RSA private key.
 
-  The easiest is to let `acme` tool generate it for you:
+  If you already have a key, you can just run:
 
         acme reg mailto:email@example.com
 
-  If you already have a key or want to generate one manually:
+  If you want to generate a key manually:
 
-        mkdir -p ~/config/acme
-        openssl genrsa -out ~/config/acme/account.pem 2048
+        mkdir -p ~/.config/acme
+        openssl genrsa -out ~/.config/acme/account.key 4096
         acme reg mailto:email@example.com
 
-  The latter version assumes that default `acme` config dir is `~/config/acme`.
+  The latter version assumes that default `acme` config dir is `~/.config/acme`.
   Yours may vary. Check with `acme help reg`.
 
   The "mailto:email@example.com" in the example above is a contact argument.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Quick install with `go get -u github.com/google/acme/cmd/acme`.
   and look for "Accepted: ..." line. If it says "no", check CA's terms document
   provided as a link in "Terms: ..." field and agree by executing:
 
-        acme update -update
+        acme update -accept
 
 3. Request a new certificate for your domain.
 


### PR DESCRIPTION
Changes the following:

0. Changes key name to account.key (not account.pem)
1. Corrects command for auto-generating a key
2. Updates config path to ~/.config/acme
3. Increases key size to 4096 bytes (why not) in the "generate key manually" docs

Regarding config path, lmk if this is dynamic on different systems and it's preferable to leave it as the previous `~/config/acme`.