### PR TITLE
cmd/acme: Add support for valid authorizations

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -330,7 +330,7 @@ func (c *Client) Authorize(ctx context.Context, domain string) (*Authorization, 
 	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
 		return nil, fmt.Errorf("acme: invalid response: %v", err)
 	}
-	if v.Status != StatusPending {
+	if v.Status != StatusPending && v.Status != StatusValid {
 		return nil, fmt.Errorf("acme: unexpected status: %s", v.Status)
 	}
 	return v.authorization(res.Header.Get("Location")), nil

--- a/cmd/acme/cert.go
+++ b/cmd/acme/cert.go
@@ -148,6 +148,9 @@ func authz(ctx context.Context, client *acme.Client, domain string) error {
 	if err != nil {
 		return err
 	}
+	if z.Status == acme.StatusValid {
+		return nil
+	}
 	var chal *acme.Challenge
 	for _, c := range z.Challenges {
 		if c.Type == "http-01" {


### PR DESCRIPTION
If a domain has been recently authorized, the API may return a valid authorization instead of a pending one. In this case, no work is required.

I also have a version of this that I can submit to the upstream package, but I figured I'd start here.