### PR TITLE
Add support for building Illumos (Solaris) binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ RELEASES=bin/acme-darwin-amd64 \
 	 bin/acme-linux-386 \
 	 bin/acme-linux-arm \
 	 bin/acme-windows-amd64.exe \
-	 bin/acme-windows-386.exe
+	 bin/acme-windows-386.exe \
+	 bin/acme-solaris-amd64 
 
 all: $(RELEASES)
 


### PR DESCRIPTION
I've made a simple addition to the `Makefile` to also build a AMD64 Illumos (Solaris) binary. I've deliberately only added the 64 bit build because I don't think anyone in Illumos / Solaris land cares about the 32 bit one.

I've done some simple testing in a Joyent Triton VM which runs SmartOS, which is Illumos based and haven't encountered any issues.