### PR TITLE
Store directory URL used by "reg" in account.json as later default

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -57,7 +57,7 @@ Default location of the config dir is
 		`,
 	}
 
-	certDisco   = defaultDiscoFlag
+	certDisco   discoAliasFlag
 	certAddr    = "127.0.0.1:8080"
 	certExpiry  = 365 * 12 * time.Hour
 	certBundle  = true
@@ -97,6 +97,13 @@ func runCert(args []string) {
 		fatalf("no key found for %s", uc.URI)
 	}
 
+	useDisco := uc.CA
+	if string(certDisco) != "" {
+		useDisco = string(certDisco)
+	} else if useDisco == "" {
+		useDisco = string(defaultDiscoFlag)
+	}
+
 	// read or generate new cert key
 	certKey, err := anyKey(certKeypath, true)
 	if err != nil {
@@ -118,7 +125,7 @@ func runCert(args []string) {
 	// we only look for http-01 challenges at the moment
 	client := &acme.Client{
 		Key:          uc.key,
-		DirectoryURL: string(certDisco),
+		DirectoryURL: useDisco,
 	}
 	for _, domain := range args {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)

--- a/reg.go
+++ b/reg.go
@@ -70,6 +70,7 @@ func runReg(args []string) {
 	}
 	uc := &userConfig{
 		Account: acme.Account{Contact: args},
+		CA:      string(regDisco),
 		key:     key,
 	}
 
@@ -79,7 +80,7 @@ func runReg(args []string) {
 	}
 	client := &acme.Client{
 		Key:          uc.key,
-		DirectoryURL: string(regDisco),
+		DirectoryURL: uc.CA,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)


### PR DESCRIPTION
When "acme reg" creates a new configuration, by writing an account.json
file, let it remember the directory URL used. Later, use that as the
default on "acme cert", unless overridden from the commandline.

Closes #53