### PR TITLE
Only listen for HTTP challenge when needed.

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -167,13 +167,6 @@ func authz(ctx context.Context, client *acme.Client, domain string) error {
 		return errors.New("no supported challenge found")
 	}
 
-	// respond to http-01 challenge
-	ln, err := net.Listen("tcp", certAddr)
-	if err != nil {
-		return fmt.Errorf("listen %s: %v", certAddr, err)
-	}
-	defer ln.Close()
-
 	switch {
 	case certManual:
 		// manual challenge response
@@ -199,6 +192,13 @@ func authz(ctx context.Context, client *acme.Client, domain string) error {
 		var x string
 		fmt.Scanln(&x)
 	default:
+		// listen for http-01 challenge
+		ln, err := net.Listen("tcp", certAddr)
+		if err != nil {
+			return fmt.Errorf("listen %s: %v", certAddr, err)
+		}
+		defer ln.Close()
+
 		// auto, via local server
 		val, err := client.HTTP01ChallengeResponse(chal.Token)
 		if err != nil {


### PR DESCRIPTION
As I'm right now only using manual challenges, I was surprised that the
code nevertheless listened on 127.0.0.1:8080 during "acme cert".

This change moves the listening setup inside the appropriate case.
UNTESTED, but it looks trivial ;-)