### PR TITLE
Disable http for manual and dns verification

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -167,13 +167,6 @@ func authz(ctx context.Context, client *acme.Client, domain string) error {
 		return errors.New("no supported challenge found")
 	}
 
-	// respond to http-01 challenge
-	ln, err := net.Listen("tcp", certAddr)
-	if err != nil {
-		return fmt.Errorf("listen %s: %v", certAddr, err)
-	}
-	defer ln.Close()
-
 	switch {
 	case certManual:
 		// manual challenge response
@@ -200,6 +193,13 @@ func authz(ctx context.Context, client *acme.Client, domain string) error {
 		fmt.Scanln(&x)
 	default:
 		// auto, via local server
+		// respond to http-01 challenge
+		ln, err := net.Listen("tcp", certAddr)
+		if err != nil {
+			return fmt.Errorf("listen %s: %v", certAddr, err)
+		}
+		defer ln.Close()
+
 		val, err := client.HTTP01ChallengeResponse(chal.Token)
 		if err != nil {
 			return err


### PR DESCRIPTION
Unless I'm missing something, http server is only needed when verifying via http.